### PR TITLE
fix: simplificar Dockerfile.proxy con script de entrada robusto

### DIFF
--- a/frontend/Dockerfile.proxy
+++ b/frontend/Dockerfile.proxy
@@ -26,20 +26,16 @@ RUN echo '<html><body><h1>CuenlyApp Temporalmente No Disponible</h1><p>El servic
 # Crear directorio para templates de nginx
 RUN mkdir -p /etc/nginx/templates
 
-# Crear template de configuración nginx
+# Crear configuración estática para Docker Compose
 RUN echo 'server { \
     listen 80; \
     server_name localhost; \
     root /usr/share/nginx/html; \
     index index.html; \
     \
-    # Configuración resolver para K8s \
-    resolver 10.96.0.10 valid=30s; \
-    \
-    # API proxy configurable \
+    # API proxy para Docker Compose \
     location ~ ^/(api|user|v2|status|process|upload|upload-xml|job|tasks|prefs|email-config|email-configs|export-templates|export|invoices) { \
-        set $$backend_upstream $${BACKEND_HOST}; \
-        proxy_pass http://$$backend_upstream; \
+        proxy_pass http://cuenlyapp-backend:8000; \
         proxy_http_version 1.1; \
         proxy_set_header Upgrade $$http_upgrade; \
         proxy_set_header Connection "upgrade"; \
@@ -56,23 +52,29 @@ RUN echo 'server { \
     } \
     \
     location /health { return 200; } \
-}' > /etc/nginx/templates/default.conf.template
+}' > /etc/nginx/conf.d/default.conf
 
-# Script de inicio personalizado
-RUN echo '#!/bin/sh \
-set -e \
-echo "🔧 Configurando nginx proxy..." \
-echo "Backend host: ${BACKEND_HOST:-cuenlyapp-backend:8000}" \
-# Usar envsubst para reemplazar variables \
-envsubst '"'"'$BACKEND_HOST'"'"' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf \
-echo "📋 Configuración nginx generada:" \
-cat /etc/nginx/conf.d/default.conf \
-echo "🚀 Iniciando nginx..." \
-exec nginx -g "daemon off;"' > /docker-entrypoint-custom.sh && \
-chmod +x /docker-entrypoint-custom.sh
+# Script de entrada que maneja tanto Docker Compose como Kubernetes
+COPY <<EOF /docker-entrypoint.sh
+#!/bin/sh
+set -e
 
-# Variable de entorno por defecto para Docker Compose
-ENV BACKEND_HOST=cuenlyapp-backend:8000
+echo "🔧 Configurando proxy nginx..."
+
+if [ -n "\$BACKEND_HOST" ]; then
+  echo "🔍 Usando BACKEND_HOST: \$BACKEND_HOST (Kubernetes)"
+  sed -i "s|cuenlyapp-backend:8000|\$BACKEND_HOST|g" /etc/nginx/conf.d/default.conf
+else
+  echo "🔍 Usando configuración por defecto (Docker Compose)"
+fi
+
+echo "📋 Configuración final:"
+cat /etc/nginx/conf.d/default.conf
+echo "🚀 Iniciando nginx..."
+exec nginx -g "daemon off;"
+EOF
+
+RUN chmod +x /docker-entrypoint.sh
 
 # Exponer puerto 80
 EXPOSE 80
@@ -81,4 +83,4 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost/ || exit 1
 
-CMD ["/docker-entrypoint-custom.sh"]
+CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
- Usar configuración estática para Docker Compose por defecto
- Script de entrada que reemplaza backend host dinámicamente
- Usar COPY heredoc para script más limpio y legible
- Manejar tanto Docker Compose (cuenlyapp-backend:8000) como K8s (variable BACKEND_HOST)
- El deployment K8s ya tiene BACKEND_HOST configurado correctamente